### PR TITLE
rosettaPTF v0.1.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rosettaPTF
 Title: R Frontend for Rosetta Pedotransfer Functions
-Version: 0.1.3
+Version: 0.1.4
 Author: Soil and Plant Science Division Staff
 Maintainer: Andrew G. Brown <andrew.g.brown@usda.gov>
 Description: Access Python rosetta-soil pedotransfer functions in an R environment. Rosetta is a neural network-based model for predicting unsaturated soil hydraulic parameters from basic soil characterization data. The model predicts parameters for the van Genuchten unsaturated soil hydraulic properties model, using sand, silt, and clay, bulk density and water content. The codebase is now maintained by Dr. Todd Skaggs and other U.S. Department of Agriculture employees. This R package is intended to provide for use cases that involve many thousands of calls to the pedotransfer function. Less demanding use cases are encouraged to use the web interface or API endpoint. There are additional wrappers of the API endpoints provided by the soilDB R package `ROSETTA()` method.

--- a/R/find_python.R
+++ b/R/find_python.R
@@ -69,7 +69,7 @@ find_python <- function(envname = NULL,
   if (length(pypath) == 0) {
 
     # find newest python installation with rosetta installed
-    x <- try(reticulate::py_discover_config("rosetta"))
+    x <- try(reticulate::py_discover_config("rosetta"), silent = TRUE)
     if (!is.null(x$python_versions)) {
       xxx <- lapply(x$python_versions, function(x) {
         y <- gsub("Python ", "", system(paste(shQuote(x), "--version"), intern = TRUE, ignore.stdout = TRUE, ignore.stderr = TRUE))
@@ -82,7 +82,7 @@ find_python <- function(envname = NULL,
 
     # otherwise find newest python installation
     if (is.null(res) || inherits(res, 'try-error')) {
-      x <- try(reticulate::py_discover_config())
+      x <- try(reticulate::py_discover_config(), silent = TRUE)
       if (!is.null(x$python_versions)) {
         xxx <- lapply(x$python_versions, function(x) {
           y <- gsub("Python ", "", system(paste(shQuote(x), "--version"), intern = TRUE, ignore.stdout = TRUE, ignore.stderr = TRUE, show.output.on.console = FALSE))

--- a/R/install_rosetta.R
+++ b/R/install_rosetta.R
@@ -20,12 +20,13 @@ install_rosetta <- function(envname = NULL,
                             arcpy_path = getOption("rosettaPTF.arcpy_path")) {
 
   # use heuristics to find python executable
-  if (!is.null(arcpy_path) && dir.exists(arcpy_path)){
+  if (!is.null(arcpy_path) && dir.exists(arcpy_path)) {
     find_python(envname = envname, arcpy_path = arcpy_path)
   }
 
   # get rosetta-soil (and numpy if needed)
-  try(reticulate::py_install("rosetta-soil", envname = envname, method = method, conda = conda, pip = pip))
+  try(reticulate::py_install("rosetta-soil", envname = envname, method = method, conda = conda, pip = pip),
+      silent = TRUE)
 
     # load modules globally in package (prevents having to reload rosettaPTF library in session)
   .loadModules()

--- a/R/run_rosetta.R
+++ b/R/run_rosetta.R
@@ -124,7 +124,7 @@ run_rosetta.RasterStack <- function(soildata,
                                     rosetta_version = 3,
                                     cores = 1,
                                     core_thresh = 20000L,
-                                    file = paste0(tempfile(),".grd"),
+                                    file = paste0(tempfile(), ".tif"),
                                     nrows = nrow(soildata) / (terra::ncell(soildata) / core_thresh),
                                     overwrite = TRUE) {
   ## for in memory only, can just convert to data.frame and use that method
@@ -156,7 +156,7 @@ run_rosetta.RasterBrick <- function(soildata,
                                     rosetta_version = 3,
                                     cores = 1,
                                     core_thresh = 20000L,
-                                    file = paste0(tempfile(),".grd"),
+                                    file = paste0(tempfile(), ".tif"),
                                     nrows = nrow(soildata) / (terra::ncell(soildata) / core_thresh),
                                     overwrite = TRUE) {
   run_rosetta(terra::rast(soildata),
@@ -182,7 +182,7 @@ run_rosetta.SpatRaster <- function(soildata,
                                    rosetta_version = 3,
                                    cores = 1,
                                    core_thresh = 20000L,
-                                   file = paste0(tempfile(),".grd"),
+                                   file = paste0(tempfile(), ".tif"),
                                    nrows = nrow(soildata) / (terra::ncell(soildata) / core_thresh),
                                    overwrite = TRUE) {
 

--- a/man/run_rosetta.Rd
+++ b/man/run_rosetta.Rd
@@ -21,8 +21,9 @@
   vars = NULL,
   rosetta_version = 3,
   cores = 1,
+  core_thresh = 20000L,
   file = paste0(tempfile(), ".grd"),
-  nrows = nrow(soildata),
+  nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )
 
@@ -31,8 +32,9 @@
   vars = NULL,
   rosetta_version = 3,
   cores = 1,
+  core_thresh = 20000L,
   file = paste0(tempfile(), ".grd"),
-  nrows = nrow(soildata),
+  nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )
 
@@ -41,8 +43,9 @@
   vars = NULL,
   rosetta_version = 3,
   cores = 1,
+  core_thresh = 20000L,
   file = paste0(tempfile(), ".grd"),
-  nrows = nrow(soildata),
+  nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )
 }
@@ -57,9 +60,11 @@
 
 \item{cores}{number of cores; used only for processing \emph{SpatRaster} or \emph{Raster*} input}
 
+\item{core_thresh}{Magic number for determining processing chunk size. Default \code{20000L}. Used to calculate default \code{nrows}}
+
 \item{file}{path to write incremental raster processing output for large inputs that do not fit in memory; passed to \code{terra::writeStart()} and used only for processing \emph{SpatRaster} or \emph{Raster*} input; defaults to a temporary file created by \code{tempfile()} if needed}
 
-\item{nrows}{number of rows to use per block; passed to \code{terra::readValues()} \code{terra::writeValues()}; used only for processing \emph{SpatRaster} or \emph{Raster*} input; defaults to number of rows in dataset if needed}
+\item{nrows}{number of rows to use per block chunk; passed to \code{terra::readValues()} and \code{terra::writeValues()}; used only for processing \emph{SpatRaster} or \emph{Raster*} inputs. Defaults to the total number of rows divided by the number of cells divided by \code{core_thresh}.}
 
 \item{overwrite}{logical; overwrite \code{file}? passed to \code{terra::writeStart()}; defaults to \code{TRUE} if needed}
 }

--- a/man/run_rosetta.Rd
+++ b/man/run_rosetta.Rd
@@ -22,7 +22,7 @@
   rosetta_version = 3,
   cores = 1,
   core_thresh = 20000L,
-  file = paste0(tempfile(), ".grd"),
+  file = paste0(tempfile(), ".tif"),
   nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )
@@ -33,7 +33,7 @@
   rosetta_version = 3,
   cores = 1,
   core_thresh = 20000L,
-  file = paste0(tempfile(), ".grd"),
+  file = paste0(tempfile(), ".tif"),
   nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )
@@ -44,7 +44,7 @@
   rosetta_version = 3,
   cores = 1,
   core_thresh = 20000L,
-  file = paste0(tempfile(), ".grd"),
+  file = paste0(tempfile(), ".tif"),
   nrows = nrow(soildata)/(terra::ncell(soildata)/core_thresh),
   overwrite = TRUE
 )

--- a/tests/testthat/test-rosetta.R
+++ b/tests/testthat/test-rosetta.R
@@ -50,11 +50,11 @@ test_that("run on SSURGO data", {
   resrose <- rosettaPTF::run_rosetta(soildata[,varnames])
   resrose$mukey <- resprop$mukey
 
-  rdf <- data.frame(mukey = as.numeric(terra::cats(res)[[1]][["category"]]))
+  rdf <- data.frame(mukey = as.numeric(terra::cats(res)[[1]][[1]]))
   rdf2 <- merge(rdf, resprop, by = "mukey", all.x = TRUE, sort = FALSE, incomparables = NA)
   rdf3 <- merge(rdf2, resrose, by = "mukey", all.x = TRUE, sort = FALSE, incomparables = NA)
   rdf3 <- rdf3[match(rdf3[["mukey"]], umukeys, incomparables = NA),][1:nrow(resprop),]
-  levels(res) <- data.frame(ID = 1:nrow(rdf3), rdf3)
+  terra::set.cats(res, 1, data.frame(ID = 1:nrow(rdf3), rdf3))
 
   # @params x a SpatRaster with `levels()` set such that `cats(x)[[1]]` defines the mapping between raster values and one or more new attributes
   # @params columns character vector of column names to map from the categorical levels to raster values


### PR DESCRIPTION
# rosettaPTF v0.1.4
## Updates to `run_rosetta()` and `install_rosetta()`
- close file connections on error (#11)
- better heuristics for `nrows` and fix for file issues (#12)
- use GeoTIFF (.tif extension) for temporary files
- fix tests
- silence errors (i.e. reticulate failing to use venv python)